### PR TITLE
Debounce triggers trailing/leading callacks, new scroll and resize events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+### 1.2.0 (2016-11-03)
+
+- NEW: Debounce can fire separate leading and trailing callbacks.
+- NEW: Debounce accepts an object as the first arg for easier configuration.
+- NEW: scrollStart, scrollStop, resizeStart, and resizeStop event managers, for debounced listening.
+- NEW: Custom `scrollStart`, `scrollStop`, `resizeStart`, and `resizeStop` debounced and optimized events.
+
+### 1.1.2 (2016-11-01)
+
+- FIX: When trailing and leading, debounce no longer queues a trailing event on the first call.
+
 ### 1.1.1 (2016-11-01)
 
 - FIX: Ensured form bubbling wouldn't be added twice.

--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ var throttle          = require( './lib/throttle' )
 var delay             = require( './lib/delay' )
 var repeat            = require( './lib/repeat' )
 var bubbleFormEvents  = require( './lib/bubble-form-events' )
+var scroll            = require( './lib/scroll' )
+var resize            = require( './lib/resize' )
 
 var slice             = Array.prototype.slice
 var formBubbling      = false

--- a/lib/debounce.js
+++ b/lib/debounce.js
@@ -2,82 +2,117 @@ var now = function() {
   return Date.now()
 }
 
-var defaults = {
-  leading: false,
-  trailing: true
+var pickFunction = function() {
+  var found
+  Array.prototype.forEach.call( arguments, function( candidate ) {
+    if ( typeof( candidate ) == 'function' && !found ) { found = candidate }
+  })
+
+  return found
 }
 
 var debounce = function( fn, wait, options ) {
-  options = options || {}
 
-  var queued      = false,
-      leading     = false,
-      trailing    = true,
-      maxTime     = options.maxTime || false,
-      leadingBlocked = false,
-      lastInvoked = 0,
-      handle      = {},
-      args;
+  // Allow options passed as the first argument
+  if ( typeof( fn ) == 'object' ) { options = fn } 
 
-  if ( 'leading' in options )  { leading = options.leading }
-  if ( 'trailing' in options )  { trailing = options.trailing }
-  
+  // Options won't be null
+  else { options = options || {} }
+
+  wait = options.wait || wait || 0
+
+  var max            = options.max || false,
+      leading        = ( ( 'leading'  in options ) ? options.leading  : false ),
+      trailing       = ( ( 'trailing' in options ) ? options.trailing : true ),
+      
+      // Grab functions from options or default to first argument
+      leadingFn      = pickFunction( options.leading, options.trailing, options.callback, fn ),
+      trailingFn     = pickFunction( options.trailing, options.leading, options.callback, fn ),
+
+      // State tracking vars
+      args,                    // Track arguments passed to debounced callback
+      queued         = false,  // Has a callback been added to the animation loop?
+      handle         = {},     // Object for tracking functions and callbacks
+      lastCalled     = 0,      // Keep a timer for debouncing
+      lastInvoked    = 0,      // Keep a timer for max
+      leadingBlocked = false;  // Track leading, throttling subsequent leading calls
+
   // Queue the function with requestAnimationFrame
-  var invoke = function() {
-    fn.apply( fn, args )
+  var invoke = function( callType ) {
+
     lastCalled = now()
     lastInvoked = now()
     queued = false
+    leadingBlocked = true
+
+    if ( callType === 'leading' ) {
+      leadingFn.apply( leadingFn, args ) }
+    else {
+      trailingFn.apply( trailingFn, args ) }
+
   }
 
   // Load the loop into the animation queue
   var addToQueue = function () {
+
     if ( !queued ) {
       queued = true
-      handle.value = requestAnimationFrame( loop )
+      handle.value = requestAnimationFrame( loop )  // Add to browser's animation queue
     }
+
   }
 
+  // Remove from animation queue and reset debounce 
   var removeFromQueue = function() {
+
     if ( "value" in handle ) {
       cancelAnimationFrame( handle.value )
-      queued = false
+      queued         = false
+      lastCalled     = 0
+      lastInvoked    = 0
       leadingBlocked = false
     }
+    
   }
 
-  // prevent infinite debouncing ( if options.maxTime is set )
-  var maxTimePassed = function() {
-    return ( maxTime && now() - lastInvoked >= maxTime )
+  // prevent infinite debouncing ( if options.max is set )
+  var maxPassed = function() {
+    return ( max && now() - lastInvoked >= max )
   }
 
   var waitReached = function() {
-    return  maxTimePassed() || now() - lastCalled >= wait
+    return ( now() - lastCalled ) >= wait
   }
 
   // This gets loaded into the animation queue and determines whether to ivoke the debounced function
-  //
   var loop = function () {
-
+  
     // Loop was executed so it's no longer in the animation queue
     queued = false
-
+    
     if ( leading && !leadingBlocked ) {
-      leadingBlocked = true
-      invoke()
+      invoke( 'leading' )
     }
 
-    if ( !waitReached() ) { 
+    // If function has been called to frequently to execute
+    else if ( maxPassed() ) {
 
-      addToQueue()
+      if ( leading ) { invoke( 'leading' )  }
+      else           { invoke( 'trailing' ) }
 
-    } else {
+    } 
+    
+    // If function hasn't been called since last wait
+    else if ( waitReached() ) {
 
       // If trailing it's safe to invoke
-      if ( trailing ) { invoke() }
+      if ( trailing ) { invoke( 'trailing' ) }
 
       // If leading, it's safe to remove block
       if ( leading )  { leadingBlocked = false }
+     
+    } else {
+      addToQueue()
     }
 
   }

--- a/lib/page-events.js
+++ b/lib/page-events.js
@@ -1,78 +1,46 @@
-var bean = require( 'bean' )
-var throttle = require( './throttle' )
+var Event = require( 'bean' )
 
-var onReady = []
-var onResizing = []
-var onChange = []
-var onScroll = []
+var readyCallbacks = []
+var changeCallbacks = []
 var readyAlready = false
-var scrollWatch = false
-var resizeWatch = false
 var pageChangeFired = false
+
+function ready( fn ) {
+  if ( readyAlready )
+    fn()
+  else
+    readyCallbacks.push( fn )
+}
+
+function change( fn ) {
+  changeCallbacks.push( fn )
+
+  // Execute immediately if pageChange has already fired
+  if ( pageChangeFired )
+    fn()
+}
+
+function pageReady(){
+
+  readyAlready = true
+  readyCallbacks.forEach( function( fn ) { fn() } )
+
+  if ( !window.Turbolinks && !pageChangeFired ) { pageChange() }
+
+}
+
+function pageChange(){
+
+  pageChangeFired = true
+  changeCallbacks.forEach( function( fn ) { fn() } )
+
+}
+
+Event.on( document, 'DOMContentLoaded', pageReady )
+Event.on( document, 'page:change', pageChange )     // Support rails turbolinks page load event
 
 module.exports = {
   ready: ready,
   change: change
 }
 
-function ready( fn ) {
-  if ( readyAlready )
-    fn()
-  else
-    onReady.push( fn )
-}
-
-function change( fn ) {
-  onChange.push( fn )
-
-  // Execute immediately if pageChange has already fired
-  if ( pageChangeFired ) 
-    fn()
-}
-
-function scroll( fn ) {
-  onScroll.push( fn )
-
-  if ( !scrollWatch ) {
-    scrollWatch = true
-    bean.on( window, 'scroll', throttle( scrolled ) )
-
-    // Trigger a custom event to allow easy listening for paint ready scroll events.
-    bean.fire( window, 'optimizedScroll' )
-  }
-}
-
-function resize( fn ) {
-  onResizing.push( fn )
-
-  if ( !resizeWatch ) {
-    resizeWatch = true
-    bean.on( window, 'resize', throttle( scrolled ) )
-
-    // Trigger a custom event to allow easy listening for paint ready resize events.
-    bean.fire( window, 'optimizedResize' )
-  }
-}
-
-function pageReady(){
-
-  readyAlready = true
-  onReady.forEach( function( fn ) { fn() } )
-
-  if ( !window.Turbolinks && !pageChangeFired ) { pageChange() }
-
-}
-
-function scrolled() {
-  onScroll.forEach( function( fn ) { fn() } )
-}
-
-function pageChange(){
-
-  pageChangeFired = true
-  onChange.forEach( function( fn ) { fn() } )
-
-}
-
-bean.on( document, 'DOMContentLoaded', pageReady )
-bean.on( document, 'page:change', pageChange )     // Support rails turbolinks page load event

--- a/lib/resize.js
+++ b/lib/resize.js
@@ -1,0 +1,56 @@
+var Event = require( 'bean' )
+var throttle = require( './throttle' )
+var debounce = require( './debounce' )
+var callbacks = { all: [], start: [], stop: []}
+
+// Event manager for firing callbacks on optimizedresize
+var resize = function( fn ) {
+  callbacks.all.push( fn ) 
+}
+
+var resizeStart = function( fn ) {
+  callbacks.start.push( fn )
+}
+
+var resizeStop = function( fn ) {
+  callbacks.stop.push( fn )
+}
+
+// Triggered by leading debounced function (when resizing starts)
+var startResize = function() {
+  Event.fire( window, 'resizeStart' ) 
+  callbacks.start.forEach( function( fn ) { fn() } )
+}
+
+// Triggered by leading debounced function (when resizing stops)
+var stopResize = function() {
+  Event.fire( window, 'resizeStop' ) 
+  callbacks.stop.forEach( function( fn ) { fn() } )
+}
+
+// A debounced function to trigger resizing start and stop events
+var resizeEvents = debounce({
+  leading: startResize,
+  trailing: stopResize,
+  wait: 150
+})
+
+// Fire custom event for easy optimized event listening
+var resized = throttle( function() {
+  
+  // Trigger a custom event to allow easy listening for paint ready resize events.
+  Event.fire( window, 'optimizedResize' )
+
+  // Trigger each function queued for optimized resizeing
+  callbacks.all.forEach( function( fn ) { fn() } )
+})
+
+// Watch the resize firehose and trigger
+// debounced and trhottled events
+Event.on( window, 'resize', function() {
+  resized()
+  resizeEvents()
+})
+
+// Export the event manager
+module.exports = resize

--- a/lib/scroll.js
+++ b/lib/scroll.js
@@ -1,0 +1,56 @@
+var Event = require( 'bean' )
+var throttle = require( './throttle' )
+var debounce = require( './debounce' )
+var callbacks = { all: [], start: [], stop: []}
+
+// Event manager for firing callbacks on optimizedScroll
+var scroll = function( fn ) {
+  callbacks.all.push( fn ) 
+}
+
+var scrollStart = function( fn ) {
+  callbacks.start.push( fn )
+}
+
+var scrollStop = function( fn ) {
+  callbacks.stop.push( fn )
+}
+
+// Triggered by leading debounced function (when scrolling starts)
+var startScroll = function() {
+  Event.fire( window, 'scrollStart' ) 
+  callbacks.start.forEach( function( fn ) { fn() } )
+}
+
+// Triggered by leading debounced function (when scrolling stops)
+var stopScroll = function() {
+  Event.fire( window, 'scrollStop' ) 
+  callbacks.stop.forEach( function( fn ) { fn() } )
+}
+
+// A debounced function to trigger scrolling start and stop events
+var scrollEvents = debounce({
+  leading: startScroll,
+  trailing: stopScroll,
+  wait: 150
+})
+
+// Fire custom event for easy optimized event listening
+var scrolled = throttle( function() {
+  
+  // Trigger a custom event to allow easy listening for paint ready scroll events.
+  Event.fire( window, 'optimizedScroll' )
+
+  // Trigger each function queued for optimized scrolling
+  callbacks.all.forEach( function( fn ) { fn() } )
+})
+
+// Watch the scroll firehose and trigger
+// debounced and trhottled events
+Event.on( window, 'scroll', function() {
+  scrolled()
+  scrollEvents()
+})
+
+// Export the event manager
+module.exports = scroll

--- a/lib/throttle.js
+++ b/lib/throttle.js
@@ -2,17 +2,17 @@ var debounce = require( './debounce' )
 
 var throttle = function( fn, wait, options ) {
 
-  options = options || {}
-  wait = wait || 0
+  if ( typeof( fn ) == 'object' ) { options = fn; fn = undefined } 
+  else { options = options || {} }
 
-  leading = 'leading' in options ? !!options.leading : true;
-  trailing = 'trailing' in options ? !!options.trailing : true;
+  options.wait = options.wait || wait || 0
+  options.max  = options.max || options.wait
+  options.callback = options.callback || fn
+  options.leading  = true
+  options.trailing = true
 
-  return debounce( fn, wait, {
-    'leading': leading,
-    'maxWait': wait,
-    'trailing': trailing
-  })
+  return debounce(options)
 }
+
 
 module.exports = throttle

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compose-event",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Event management utility unifying microjs event frameworks",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- NEW: Debounce can fire separate leading and trailing callbacks.
- NEW: Debounce accepts an object as the first arg for easier configuration.
- NEW: scrollStart, scrollStop, resizeStart, and resizeStop event managers, for debounced listening.
- NEW: Custom `scrollStart`, `scrollStop`, `resizeStart`, and `resizeStop` debounced and optimized events.