### PR TITLE
Switch to compose-ui/bean to gain useCapture param

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Event management utility, unifying microjs event frameworks",
   "main": "index.js",
   "scripts": {
-    "test": "mochify --reporter spec"
+    "test": "mochify --reporter spec",
+    "debug": "mochify --debug --reporter spec"
   },
   "repository": {
     "type": "git",
@@ -24,11 +25,12 @@
     "test": "test"
   },
   "dependencies": {
-    "bean": "^1.0.14",
+    "bean": "compose-ui/bean#1.0.15",
     "keymaster": "^1.6.2"
   },
   "devDependencies" : {
     "chai": "^3.5.0",
-    "mochify": "^2.17.0"
+    "mochify": "^2.17.0",
+    "sinon": "1.17.7"
   }
 }

--- a/test/events.js
+++ b/test/events.js
@@ -1,5 +1,6 @@
 var assert = require('chai').assert
 var event = require('../')
+var sinon = require('sinon')
 window.env = 'test'
 
 document.querySelector('body').innerHTML = '<div id="test"></div>'
@@ -35,6 +36,51 @@ describe('Events', function(){
 
     event.fire(testEl, 'testarg')
     assert.equal(testEl.textContent, 'regular event + argument')
+    done()
+  })
+
+  it('should use capture if useCapture is true', function(done) {
+    var addEventListenerSpy = sinon.spy(document, 'addEventListener'),
+      mock = sinon.mock(),
+      usedCapture
+
+    event.on(document, 'click', '#test', mock, {useCapture: true})
+
+    usedCapture = addEventListenerSpy.getCall(0).args[2]
+    assert.isTrue(usedCapture)
+
+    event.off(document, 'click', mock, {useCapture: true});
+    document.addEventListener.restore()
+    done()
+  })
+
+  it('should not use capture if useCapture is false', function(done) {
+    var addEventListenerSpy = sinon.spy(document, 'addEventListener'),
+      mock = sinon.mock(),
+      usedCapture
+
+    event.on(document, 'click', '#test', mock, {useCapture: false})
+
+    usedCapture = addEventListenerSpy.getCall(0).args[2]
+    assert.isFalse(usedCapture)
+
+    event.off(document, 'click', mock);
+    document.addEventListener.restore()
+    done()
+  })
+
+  it('should not use capture if useCapture is unspecified', function(done) {
+    var addEventListenerSpy = sinon.spy(document, 'addEventListener'),
+      mock = sinon.mock(),
+      usedCapture
+
+    event.on(document, 'click', '#test', mock)
+
+    usedCapture = addEventListenerSpy.getCall(0).args[2]
+    assert.isFalse(usedCapture)
+
+    event.off(document, 'click', mock);
+    document.addEventListener.restore()
     done()
   })
   


### PR DESCRIPTION
This patch switches to the compose-ui fork of bean, so that we can use the new `useCapture` parameter.

Also: the patch adds a `debug` script entry in package.json, so that developers can use `debugger` statements to debug during test runs.